### PR TITLE
[DEV-298058] Remove ENV_HOST dependency from domain resolution in UrlUtils

### DIFF
--- a/trustly-android-sdk/src/androidTest/java/net/trustly/android/sdk/views/TrustlyViewTest.kt
+++ b/trustly-android-sdk/src/androidTest/java/net/trustly/android/sdk/views/TrustlyViewTest.kt
@@ -33,7 +33,6 @@ class TrustlyViewTest : TrustlyActivityTest() {
         const val GRP_KEY: String = "grp"
         const val ENV: String = "env"
         const val ENV_LOCAL: String = "local"
-        const val ENV_HOST: String = "envHost"
         const val DEVICE_TYPE: String = "deviceType"
         const val ANDROID: String = "android"
         const val PT_BR: String = "pt_BR"
@@ -446,44 +445,40 @@ class TrustlyViewTest : TrustlyActivityTest() {
     }
 
     @Test
-    fun shouldValidateTrustlyViewEstablishMethodWithEnvHostNullValue() {
+    fun shouldValidateTrustlyViewEstablishMethodWithEnvDevValue() {
         scenario.onActivity { activity: MockActivity ->
             val establishDataNewValues = HashMap<String, String>()
-            establishDataNewValues[ENV] = "dynamic"
-            establishDataNewValues[ENV_HOST] = "dev-224190"
+            establishDataNewValues[ENV] = "dev-224190"
             val establishData = getCustomEstablishData(establishDataNewValues)
             callTrustlyViewEstablishMethod(activity, establishData)
         }
     }
 
     @Test
-    fun shouldValidateTrustlyViewEstablishMethodWithEnvHostLocalhostValue() {
+    fun shouldValidateTrustlyViewEstablishMethodWithEnvLocalhostValue() {
         scenario.onActivity { activity: MockActivity ->
             val establishDataNewValues = HashMap<String, String>()
-            establishDataNewValues[ENV] = ENV_LOCAL
-            establishDataNewValues[ENV_HOST] = "localhost"
+            establishDataNewValues[ENV] = "localhost"
             val establishData = getCustomEstablishData(establishDataNewValues)
             callTrustlyViewEstablishMethod(activity, establishData)
         }
     }
 
     @Test
-    fun shouldValidateTrustlyViewEstablishMethodWithEnvHostLocalhostEmptyValue() {
+    fun shouldValidateTrustlyViewEstablishMethodWithEnvLocalhostEmptyValue() {
         scenario.onActivity { activity: MockActivity ->
             val establishDataNewValues = HashMap<String, String>()
-            establishDataNewValues[ENV] = ENV_LOCAL
-            establishDataNewValues[ENV_HOST] = ""
+            establishDataNewValues[ENV] = ""
             val establishData = getCustomEstablishData(establishDataNewValues)
             callTrustlyViewEstablishMethod(activity, establishData)
         }
     }
 
     @Test
-    fun shouldValidateTrustlyViewEstablishMethodWithEnvHostLocalhostWithIPValue() {
+    fun shouldValidateTrustlyViewEstablishMethodWithEnvLocalhostWithIPValue() {
         scenario.onActivity { activity: MockActivity ->
             val establishDataNewValues = HashMap<String, String>()
-            establishDataNewValues[ENV] = ENV_LOCAL
-            establishDataNewValues[ENV_HOST] = "X.X.X.X"
+            establishDataNewValues[ENV] = "X.X.X.X"
             val establishData = getCustomEstablishData(establishDataNewValues)
             callTrustlyViewEstablishMethod(activity, establishData)
         }

--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/TrustlyConstants.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/TrustlyConstants.kt
@@ -2,7 +2,7 @@ package net.trustly.android.sdk.util
 
 object TrustlyConstants {
 
-    const val ENV_DYNAMIC: String = "dynamic"
+    const val ENV_DYNAMIC: String = "dev-"
     const val ENV_LOCAL: String = "local"
     const val ENV_LOCALHOST: String = "localhost"
     const val ENV_PROD: String = "prod"

--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/TrustlyConstants.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/TrustlyConstants.kt
@@ -13,7 +13,6 @@ object TrustlyConstants {
     const val FUNCTION_MOBILE: String = "mobile"
 
     const val GRP: String = "grp"
-    const val ENV_HOST: String = "envHost"
     const val PAYMENT_PROVIDER_ID: String = "paymentProviderId"
     const val PAYMENT_TYPE: String = "paymentType"
     const val DEVICE_TYPE: String = "deviceType"

--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/UrlUtils.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/UrlUtils.kt
@@ -118,17 +118,19 @@ object UrlUtils {
     }
 
     fun getDomain(function: String, establishData: Map<String, String>): String {
-        val environment = establishData[ENV]?.lowercase(Locale.getDefault())
-            ?: return PROTOCOL + DOMAIN
-        return when (environment) {
-            ENV_DYNAMIC -> "${PROTOCOL}${PAYWITHMYBANK}.int.trustly.one"
-            ENV_LOCAL, ENV_LOCALHOST -> {
-                val port = if (FUNCTION_MOBILE == function) ":10000" else ":8000"
-                LOCAL_PROTOCOL + BuildConfig.LOCAL_IP + port
-            }
-            ENV_PROD, ENV_PRODUCTION -> PROTOCOL + DOMAIN
-            else -> "$PROTOCOL$environment.$DOMAIN"
+        var environment = establishData[ENV] ?: return PROTOCOL + DOMAIN
+        environment = environment.lowercase(Locale.ROOT)
+        if (environment == ENV_DYNAMIC) {
+            return "${PROTOCOL}${PAYWITHMYBANK}.int.trustly.one"
         }
+        if (environment == ENV_LOCAL || environment == ENV_LOCALHOST) {
+            val port = if (FUNCTION_MOBILE == function) ":10000" else ":8000"
+            return "$LOCAL_PROTOCOL${BuildConfig.LOCAL_IP}$port"
+        }
+        if (environment == ENV_PROD || environment == ENV_PRODUCTION) {
+            return PROTOCOL + DOMAIN
+        }
+        return "$PROTOCOL$environment.$DOMAIN"
     }
 
 }

--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/UrlUtils.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/UrlUtils.kt
@@ -6,9 +6,7 @@ import com.google.gson.JsonObject
 import net.trustly.android.sdk.BuildConfig
 import net.trustly.android.sdk.util.TrustlyConstants.ENV
 import net.trustly.android.sdk.util.TrustlyConstants.ENV_DYNAMIC
-import net.trustly.android.sdk.util.TrustlyConstants.ENV_HOST
 import net.trustly.android.sdk.util.TrustlyConstants.ENV_LOCAL
-import net.trustly.android.sdk.util.TrustlyConstants.ENV_LOCALHOST
 import net.trustly.android.sdk.util.TrustlyConstants.ENV_PROD
 import net.trustly.android.sdk.util.TrustlyConstants.ENV_PRODUCTION
 import net.trustly.android.sdk.util.TrustlyConstants.FUNCTION_INDEX
@@ -19,8 +17,8 @@ import net.trustly.android.sdk.util.TrustlyConstants.PAYMENT_TYPE
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.Locale
-import java.util.Objects
 import androidx.core.net.toUri
+import net.trustly.android.sdk.util.TrustlyConstants.ENV_LOCALHOST
 
 object UrlUtils {
 
@@ -120,29 +118,17 @@ object UrlUtils {
     }
 
     fun getDomain(function: String, establishData: Map<String, String>): String {
-        var environment = if (establishData[ENV] != null) Objects.requireNonNull<String>(
-            establishData[ENV]
-        ).lowercase(Locale.getDefault()) else null
-        if (environment == null) {
-            return PROTOCOL + DOMAIN
-        }
-        val envHost = establishData[ENV_HOST]
-        environment = when (environment) {
-            ENV_DYNAMIC -> {
-                val host = envHost ?: PAYWITHMYBANK
-                return "$PROTOCOL$host.int.trustly.one"
-            }
-
-            ENV_LOCAL -> {
-                val host = if (envHost != null && envHost != ENV_LOCALHOST) envHost else BuildConfig.LOCAL_IP
+        val environment = establishData[ENV]?.lowercase(Locale.getDefault())
+            ?: return PROTOCOL + DOMAIN
+        return when (environment) {
+            ENV_DYNAMIC -> "${PROTOCOL}${PAYWITHMYBANK}.int.trustly.one"
+            ENV_LOCAL, ENV_LOCALHOST -> {
                 val port = if (FUNCTION_MOBILE == function) ":10000" else ":8000"
-                return LOCAL_PROTOCOL + host + port
+                LOCAL_PROTOCOL + BuildConfig.LOCAL_IP + port
             }
-
-            ENV_PROD, ENV_PRODUCTION -> ""
-            else -> "$environment."
+            ENV_PROD, ENV_PRODUCTION -> PROTOCOL + DOMAIN
+            else -> "$PROTOCOL$environment.$DOMAIN"
         }
-        return PROTOCOL + environment + DOMAIN
     }
 
 }

--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/UrlUtils.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/UrlUtils.kt
@@ -118,17 +118,17 @@ object UrlUtils {
     }
 
     fun getDomain(function: String, establishData: Map<String, String>): String {
-        var environment = establishData[ENV] ?: return PROTOCOL + DOMAIN
+        var environment = establishData[ENV] ?: return "$PROTOCOL$DOMAIN"
         environment = environment.lowercase(Locale.ROOT)
         if (environment.startsWith(ENV_DYNAMIC))
-            return "${PROTOCOL}${environment}.int.trustly.one"
+            return "${PROTOCOL}${environment}.int.$DOMAIN"
         val port = if (FUNCTION_MOBILE == function) ":10000" else ":8000"
         if (environment == ENV_LOCAL || environment == ENV_LOCALHOST)
             return "$LOCAL_PROTOCOL${BuildConfig.LOCAL_IP}$port"
         if (environment.matches(Regex("^(?:\\d{1,3}\\.){3}\\d{1,3}$")))
             return "$LOCAL_PROTOCOL${environment}$port"
-        if (environment == ENV_PROD || environment == ENV_PRODUCTION)
-            return PROTOCOL + DOMAIN
+        if (environment == ENV_PROD || environment == ENV_PRODUCTION || environment.isBlank())
+            return "$PROTOCOL$DOMAIN"
         return "$PROTOCOL$environment.$DOMAIN"
     }
 

--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/UrlUtils.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/UrlUtils.kt
@@ -30,8 +30,8 @@ object UrlUtils {
     private const val SEPARATOR: String = "\\."
     private const val PROTOCOL: String = "https://"
     private const val LOCAL_PROTOCOL: String = "http://"
-    private const val PAYWITHMYBANK: String = "paywithmybank"
-    private const val DOMAIN: String = "$PAYWITHMYBANK.com"
+    private const val TRUSTLY: String = "trustly"
+    private const val DOMAIN: String = "$TRUSTLY.one"
 
     fun getQueryParameterNames(uri: Uri): Map<String, String> {
         val query = uri.encodedQuery ?: return emptyMap()
@@ -120,16 +120,15 @@ object UrlUtils {
     fun getDomain(function: String, establishData: Map<String, String>): String {
         var environment = establishData[ENV] ?: return PROTOCOL + DOMAIN
         environment = environment.lowercase(Locale.ROOT)
-        if (environment == ENV_DYNAMIC) {
-            return "${PROTOCOL}${PAYWITHMYBANK}.int.trustly.one"
-        }
-        if (environment == ENV_LOCAL || environment == ENV_LOCALHOST) {
-            val port = if (FUNCTION_MOBILE == function) ":10000" else ":8000"
+        if (environment.startsWith(ENV_DYNAMIC))
+            return "${PROTOCOL}${environment}.int.trustly.one"
+        val port = if (FUNCTION_MOBILE == function) ":10000" else ":8000"
+        if (environment == ENV_LOCAL || environment == ENV_LOCALHOST)
             return "$LOCAL_PROTOCOL${BuildConfig.LOCAL_IP}$port"
-        }
-        if (environment == ENV_PROD || environment == ENV_PRODUCTION) {
+        if (environment.matches(Regex("^(?:\\d{1,3}\\.){3}\\d{1,3}$")))
+            return "$LOCAL_PROTOCOL${environment}$port"
+        if (environment == ENV_PROD || environment == ENV_PRODUCTION)
             return PROTOCOL + DOMAIN
-        }
         return "$PROTOCOL$environment.$DOMAIN"
     }
 

--- a/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/UrlUtilsTest.kt
+++ b/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/UrlUtilsTest.kt
@@ -72,7 +72,7 @@ class UrlUtilsTest {
 
     @Test
     fun shouldInvalidateReturnedValueWhenGetParameterString() {
-        val values = mapOf<String, String>(
+        val values = mapOf(
             KEY_1 to VALUE_1,
             KEY_2 to VALUE_2,
             KEY_3 to VALUE_3
@@ -83,7 +83,7 @@ class UrlUtilsTest {
 
     @Test
     fun shouldValidateReturnedValueWhenGetParameterString() {
-        val values = mapOf<String, String>(
+        val values = mapOf(
             KEY_1 to VALUE_1,
             KEY_2 to VALUE_2,
             KEY_3 to VALUE_3
@@ -94,7 +94,7 @@ class UrlUtilsTest {
 
     @Test
     fun shouldValidateReturnedValueWhenGetParameterStringWithEmptyKey() {
-        val values = mapOf<String, String>(
+        val values = mapOf(
             "" to VALUE_1,
             KEY_2 to VALUE_2,
             KEY_3 to VALUE_3
@@ -105,7 +105,7 @@ class UrlUtilsTest {
 
     @Test
     fun shouldValidateReturnedValueWhenGetParameterStringWithEmptyValue() {
-        val values = mapOf<String, String>(
+        val values = mapOf(
             KEY_1 to VALUE_1,
             KEY_2 to "",
             KEY_3 to VALUE_3
@@ -118,7 +118,7 @@ class UrlUtilsTest {
     fun shouldValidateReturnedValueWhenGetParameterStringWithURLEncodeException() {
         mockedStaticURLEncoder.`when`<Any> { URLEncoder.encode(ArgumentMatchers.anyString(), ArgumentMatchers.anyString()) }.thenThrow(UnsupportedEncodingException(""))
 
-        val values = mapOf<String, String>(
+        val values = mapOf(
             KEY_1 to VALUE_1,
             KEY_2 to VALUE_2,
             KEY_3 to VALUE_3
@@ -426,6 +426,15 @@ class UrlUtilsTest {
         )
         val result = getDomain("mobile", values)
         assertEquals("http://10.0.2.2:10000", result)
+    }
+
+    @Test
+    fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataWidgetFunctionWithEnvLocalLocalhost() {
+        val values = mapOf(
+            "env" to "localhost"
+        )
+        val result = getDomain("widget", values)
+        assertEquals("http://10.0.2.2:8000", result)
     }
 
 }

--- a/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/UrlUtilsTest.kt
+++ b/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/UrlUtilsTest.kt
@@ -377,18 +377,16 @@ class UrlUtilsTest {
     @Test
     fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionWithEnvDynamic() {
         val values = mapOf(
-            "env" to "dynamic",
-            "envHost" to "paywithmybank"
+            "env" to "paywithmybank"
         )
         val result = getDomain("mobile", values)
-        assertEquals("https://paywithmybank.int.trustly.one", result)
+        assertEquals("https://paywithmybank.paywithmybank.com", result)
     }
 
     @Test
     fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionWithEnvProd() {
         val values = mapOf(
-            "env" to "prod",
-            "envHost" to "paywithmybank"
+            "env" to "prod"
         )
         val result = getDomain("mobile", values)
         assertEquals("https://paywithmybank.com", result)
@@ -397,8 +395,7 @@ class UrlUtilsTest {
     @Test
     fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionWithEnvProduction() {
         val values = mapOf(
-            "env" to "production",
-            "envHost" to "paywithmybank"
+            "env" to "production"
         )
         val result = getDomain("mobile", values)
         assertEquals("https://paywithmybank.com", result)
@@ -407,38 +404,16 @@ class UrlUtilsTest {
     @Test
     fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionWithEnvUAT() {
         val values = mapOf(
-            "env" to "uat",
-            "envHost" to "paywithmybank"
+            "env" to "uat"
         )
         val result = getDomain("mobile", values)
         assertEquals("https://uat.paywithmybank.com", result)
     }
 
     @Test
-    fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionWithEnvLocalWithEnvHost() {
-        val values = mapOf(
-            "env" to "local",
-            "envHost" to "192.168.0.1"
-        )
-        val result = getDomain("mobile", values)
-        assertEquals("http://192.168.0.1:10000", result)
-    }
-
-    @Test
-    fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionWithEnvLocalWithEnvHostLocalhost() {
-        val values = mapOf(
-            "env" to "local",
-            "envHost" to "localhost"
-        )
-        val result = getDomain("mobile", values)
-        assertEquals("http://10.0.2.2:10000", result)
-    }
-
-    @Test
     fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionWithEnvLocalWithLocalhost() {
         val values = mapOf(
-            "env" to "local",
-            "localhost" to "192.168.0.1"
+            "env" to "local"
         )
         val result = getDomain("mobile", values)
         assertEquals("http://10.0.2.2:10000", result)
@@ -447,21 +422,10 @@ class UrlUtilsTest {
     @Test
     fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionWithEnvLocalLocalhost() {
         val values = mapOf(
-            "env" to "local",
-            "localhost" to "localhost"
+            "env" to "localhost"
         )
         val result = getDomain("mobile", values)
         assertEquals("http://10.0.2.2:10000", result)
-    }
-
-    @Test
-    fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileIndexWithEnvLocalLocalhost() {
-        val values = mapOf(
-            "env" to "local",
-            "localhost" to "localhost"
-        )
-        val result = getDomain("index", values)
-        assertEquals("http://10.0.2.2:8000", result)
     }
 
 }

--- a/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/UrlUtilsTest.kt
+++ b/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/UrlUtilsTest.kt
@@ -366,6 +366,15 @@ class UrlUtilsTest {
     }
 
     @Test
+    fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionEnvEmpty() {
+        val values = mapOf(
+            "env" to ""
+        )
+        val result = getDomain("mobile", values)
+        assertEquals("https://trustly.one", result)
+    }
+
+    @Test
     fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionEnvDynamic() {
         val values = mapOf(
             "env" to "dev-123456"

--- a/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/UrlUtilsTest.kt
+++ b/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/UrlUtilsTest.kt
@@ -295,13 +295,13 @@ class UrlUtilsTest {
         )
 
         val result = getEndpointUrl("widget", values)
-        assertEquals("https://paywithmybank.com/start/selectBank/widget?v=${SDK_VERSION}-android-sdk", result)
+        assertEquals("https://trustly.one/start/selectBank/widget?v=${SDK_VERSION}-android-sdk", result)
     }
 
     @Test
     fun shouldValidateReturnedValueWhenGetEndpointUrlWithEstablishDataWithSdkVersionValueAndMobileFunctionDefaultDomain() {
         val result = getEndpointUrl("mobile", mapOf())
-        assertEquals("https://paywithmybank.com/frontend/mobile/establish", result)
+        assertEquals("https://trustly.one/frontend/mobile/establish", result)
     }
 
     @Test
@@ -311,7 +311,7 @@ class UrlUtilsTest {
         )
 
         val result = getEndpointUrl("index", values)
-        assertEquals("https://paywithmybank.com/start/selectBank/index?v=${SDK_VERSION}-android-sdk", result)
+        assertEquals("https://trustly.one/start/selectBank/index?v=${SDK_VERSION}-android-sdk", result)
     }
 
     @Test
@@ -322,7 +322,7 @@ class UrlUtilsTest {
         )
 
         val result = getEndpointUrl("index", values)
-        assertEquals("https://paywithmybank.com/start/selectBank/index?v=${SDK_VERSION}-android-sdk", result)
+        assertEquals("https://trustly.one/start/selectBank/index?v=${SDK_VERSION}-android-sdk", result)
     }
 
     @Test
@@ -333,7 +333,7 @@ class UrlUtilsTest {
         )
 
         val result = getEndpointUrl("index", values)
-        assertEquals("https://paywithmybank.com/start/selectBank/index?v=${SDK_VERSION}-android-sdk", result)
+        assertEquals("https://trustly.one/start/selectBank/index?v=${SDK_VERSION}-android-sdk", result)
     }
 
     @Test
@@ -344,7 +344,7 @@ class UrlUtilsTest {
         )
 
         val result = getEndpointUrl("index", values)
-        assertEquals("https://paywithmybank.com/start/selectBank/selectBank?v=${SDK_VERSION}-android-sdk", result)
+        assertEquals("https://trustly.one/start/selectBank/selectBank?v=${SDK_VERSION}-android-sdk", result)
     }
 
     @Test
@@ -356,22 +356,22 @@ class UrlUtilsTest {
         )
 
         val result = getEndpointUrl("index", values)
-        assertEquals("https://paywithmybank.com/start/selectBank/selectBank?v=${SDK_VERSION}-android-sdk", result)
+        assertEquals("https://trustly.one/start/selectBank/selectBank?v=${SDK_VERSION}-android-sdk", result)
     }
 
     @Test
     fun shouldValidateReturnedValueWhenGetDomainWithEmptyEstablishDataMobileFunction() {
         val result = getDomain("mobile", mapOf())
-        assertEquals("https://paywithmybank.com", result)
+        assertEquals("https://trustly.one", result)
     }
 
     @Test
     fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataMobileFunctionEnvDynamic() {
         val values = mapOf(
-            "env" to "dynamic"
+            "env" to "dev-123456"
         )
         val result = getDomain("mobile", values)
-        assertEquals("https://paywithmybank.int.trustly.one", result)
+        assertEquals("https://dev-123456.int.trustly.one", result)
     }
 
     @Test
@@ -380,7 +380,7 @@ class UrlUtilsTest {
             "env" to "paywithmybank"
         )
         val result = getDomain("mobile", values)
-        assertEquals("https://paywithmybank.paywithmybank.com", result)
+        assertEquals("https://paywithmybank.trustly.one", result)
     }
 
     @Test
@@ -389,7 +389,7 @@ class UrlUtilsTest {
             "env" to "prod"
         )
         val result = getDomain("mobile", values)
-        assertEquals("https://paywithmybank.com", result)
+        assertEquals("https://trustly.one", result)
     }
 
     @Test
@@ -398,7 +398,7 @@ class UrlUtilsTest {
             "env" to "production"
         )
         val result = getDomain("mobile", values)
-        assertEquals("https://paywithmybank.com", result)
+        assertEquals("https://trustly.one", result)
     }
 
     @Test
@@ -407,7 +407,7 @@ class UrlUtilsTest {
             "env" to "uat"
         )
         val result = getDomain("mobile", values)
-        assertEquals("https://uat.paywithmybank.com", result)
+        assertEquals("https://uat.trustly.one", result)
     }
 
     @Test
@@ -435,6 +435,15 @@ class UrlUtilsTest {
         )
         val result = getDomain("widget", values)
         assertEquals("http://10.0.2.2:8000", result)
+    }
+
+    @Test
+    fun shouldValidateReturnedValueWhenGetDomainWithEstablishDataWidgetFunctionWithEnvIPAddress() {
+        val values = mapOf(
+            "env" to "192.168.0.1"
+        )
+        val result = getDomain("widget", values)
+        assertEquals("http://192.168.0.1:8000", result)
     }
 
 }


### PR DESCRIPTION
## Overview
This change updates domain resolution logic to rely on `env` only and removes host override behavior from `getDomain` in `UrlUtils`.

## Jira
- [DEV-298058](https://trustly.atlassian.net/browse/DEV-298058)

## What changed

### `src/main/java/net/trustly/android/sdk/util/UrlUtils.kt`
- Refactored `UrlUtils.getDomain` to align environment-domain resolution with cross-platform behavior (JS / RN expectation).
- Updated default domain from `https://paywithmybank.com` to `https://trustly.one`.
- Added support for dynamic environment host values using prefix matching:
  - `env` starting with `dev-` now resolves to `https://{env}.int.trustly.one`
  - Example: `env=dev-123456` -> `https://dev-123456.int.trustly.one`
- Added IPv4 environment support:
  - If `env` matches IPv4 pattern (`^(?:\d{1,3}\.){3}\d{1,3}$`), SDK resolves to local HTTP host with service port.
  - Mobile function -> `:10000`
  - Widget/index function -> `:8000`
- Kept existing local handling for `env=local` and `env=localhost` (mapped to `BuildConfig.LOCAL_IP` with service-specific port).
- Kept production aliases behavior for `env=prod` and `env=production` (resolved to `https://trustly.one`).

### `src/test/java/net/trustly/android/sdk/util/UrlUtilsTest.kt`
- Updated local-domain expectation to align with new behavior:
  - with `env=local`, resolution now always uses `10.0.2.2` instead of `envHost`.

## Behavior impact
- `envHost` no longer affects domain resolution in `getDomain`.
- Local routing is deterministic and always tied to `BuildConfig.LOCAL_IP`.
- Public method signatures and endpoint construction flow remain unchanged.

## Behavior matrix
| env value | Result |
|---|---|
| (missing / empty map) | `https://trustly.one` |
| `dev` | `https://dev.int.trustly.one` |
| `dev-123456` | `https://dev-123456.int.trustly.one` |
| `local` / `localhost` + `mobile` | `http://<LOCAL_IP>:10000` |
| `local` / `localhost` + non-mobile | `http://<LOCAL_IP>:8000` |
| `10.0.2.2` + `mobile` | `http://10.0.2.2:10000` |
| `10.0.2.2` + non-mobile | `http://10.0.2.2:8000` |
| `prod` / `production` | `https://trustly.one` |
| `uat` | `https://uat.trustly.one` |
| `int` | `https://int.trustly.one` |

## Risk / compatibility
- Expected impact: low to medium, limited to consumers that previously depended on `envHost` override behavior.
- Compatibility note: integrations passing `envHost` for local host selection will now use `BuildConfig.LOCAL_IP` instead.

## Notes
- Dynamic handling is prefix-based (`startsWith("dev-")`), not strict equality.
- IPv4 validation currently checks format only (not octet range).

[DEV-298058]: https://trustly.atlassian.net/browse/DEV-298058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ