### PR TITLE
[DEV-300078] Migration Guide - v3 to v4

### DIFF
--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -1,0 +1,376 @@
+# Trustly Android SDK v3.7.0 to v4.2.0 Migration Guide for Merchant Teams
+
+## Who This Guide Is For
+
+This document is for merchant Android engineers upgrading an existing Trustly Android SDK v3.7.0 integration to v4.2.0.
+
+It is written as an implementation guide, not a codebase audit.
+
+## What Changes for Your App
+
+### High-impact changes
+
+1. SDK dependency updates from 3.7.0 to 4.2.0.
+2. v4 encapsulates secure-browser redirect handling inside the SDK:
+   - `TrustlyCustomTabsManagerActivity`
+   - `TrustlyRedirectActivity`
+3. Merchant apps can remove manual redirect Activity implementations and set only the URL scheme resource:
+    - `<string name="trustly_url_scheme">url_scheme</string>`
+4. Callback routing is internally refactored through `TrustlyEvents`, while merchant-facing callback registration remains on `Trustly`/`TrustlyView`.
+
+### What stays mostly the same
+
+1. Core integration object remains `TrustlyView` implementing `Trustly`.
+2. Main flow methods remain:
+   - `selectBankWidget(establishData)`
+   - `establish(establishData)`
+   - `onBankSelected(...)`
+   - `onReturn(...)`
+   - `onCancel(...)`
+   - `setListener(...)`
+3. Required establish base fields remain the same (`accessId`, `merchantId`, `merchantReference`, `returnUrl`, `cancelUrl`, `requestSignature`).
+
+---
+
+## Migration at a Glance
+
+### v3.7.0 to v4.2.0 mapping
+
+| v3.7.0 pattern | v4.2.0 pattern |
+|---|---|
+| `implementation 'net.trustly:trustly-android-sdk:3.7.0'` | `implementation 'net.trustly:trustly-android-sdk:4.2.0'` |
+| Deprecated `Trustly.Instance.create(context)` helper exists | Use `TrustlyView(context)` directly |
+| `TrustlyView` contains env-based constructors (for example `TrustlyView(context, env)`) | Constructor simplified to `TrustlyView(context, attrs?)`; pass environment in establish data |
+| Custom tabs launch handled directly in v3 utility path | v4 uses SDK activities for secure-browser flow and redirect callback handling |
+| Callback invocation handled directly in `TrustlyView` | Callback registration unchanged; dispatch refactored via `TrustlyEvents` |
+
+---
+
+## Step-by-Step Upgrade Plan
+
+## 1. Update SDK dependency to v4.2.0
+
+Change your app dependency:
+
+```gradle
+dependencies {
+    implementation 'net.trustly:trustly-android-sdk:4.2.0'
+}
+```
+
+Keep this PR small: dependency bump and build verification first.
+
+## 2. Verify build tooling compatibility
+
+Observed SDK-side tooling deltas between these versions:
+
+1. Android Gradle Plugin: `8.11.0` -> `8.12.0`
+2. Gradle wrapper: `8.14.2` -> `8.14.3`
+3. targetSdkVersion in SDK project: `34` -> `36`
+
+For merchant apps, align your Android toolchain to a modern AGP/Gradle combination compatible with your project and CI.
+
+## 3. Keep using `TrustlyView` + `Trustly` flow methods
+
+Your host-side integration pattern remains:
+
+1. Set callbacks (`onBankSelected`, `onReturn`, `onCancel`, optional `setListener`).
+2. Render bank widget (`selectBankWidget`).
+3. Launch light-box (`establish`) when bank/provider is selected.
+
+No `TrustlyPanel` API was found in either v3 or v4 repository.
+
+## 4. Validate deep-link return behavior in v4
+
+SDK 4.2.0 encapsulates redirect flow with SDK-owned activities.
+
+Action items:
+
+1. Delete your manual redirect Activity class from the merchant app, if present.
+2. Add your scheme to `strings.xml`:
+
+```xml
+<string name="trustly_url_scheme">url_scheme</string>
+```
+
+3. Choose one deep-link strategy in establish payload:
+    - URL scheme: `metadata.urlScheme`
+    - App Links: `metadata.deepLinkUrl`
+4. `metadata.urlScheme` and `metadata.deepLinkUrl` are mutually exclusive. Send only one, never both.
+5. App Links require additional configuration (for example, AndroidManifest intent filters, Digital Asset Links, and domain association validation).
+6. `metadata.deepLinkUrl` (App Links) is new and also requires Trustly-side configuration/enablement.
+7. Contact Trustly Support to enable App Links before rollout.
+8. Test return-to-app behavior on real devices.
+
+## 5. Re-test callback behavior end-to-end
+
+Run full flow tests for:
+
+1. Success path (`onReturn`).
+2. Cancel/failure path (`onCancel`).
+3. Bank selection (`onBankSelected`).
+4. Telemetry/events (`setListener`).
+
+---
+
+## Task 1: API Changes
+
+## A. Trustly / related API differences
+
+### Public interfaces
+
+v3 interface style:
+
+- Java `interface Trustly`
+- Java `interface TrustlyCallback<T, V>`
+- Java `interface TrustlyListener`
+- Deprecated factory helper via `Trustly.Instance.create(context)`
+
+v4 interface style:
+
+- Kotlin `interface Trustly`
+- Kotlin `fun interface TrustlyCallback<T, V>`
+- Kotlin `fun interface TrustlyListener`
+- Added internal `TrustlyEvents` abstraction for callback/event dispatch
+
+### Behavioral notes
+
+1. Merchant-facing callback registration points are still on `Trustly`/`TrustlyView`.
+2. `hybrid(...)` is documented as deprecated in v4 and marked as not available in future versions.
+3. `proceedToChooseAccount()` remains available in both versions.
+
+## B. build.gradle / dependency differences
+
+### Dependency string
+
+v3:
+
+```gradle
+implementation 'net.trustly:trustly-android-sdk:3.7.0'
+```
+
+v4:
+
+```gradle
+implementation 'net.trustly:trustly-android-sdk:4.2.0'
+```
+
+### SDK project-level technical deltas (useful for migration planning)
+
+1. `com.android.library` plugin: `8.11.0` -> `8.12.0`
+2. `targetSdkVersion`: `34` -> `36`
+3. Gradle wrapper distribution: `8.14.2` -> `8.14.3`
+
+## C. AndroidManifest permissions
+
+### Permission changes
+
+No required `uses-permission` entries were found in either SDK manifest.
+
+### Component changes in v4
+
+v4 introduces manifest-declared activities for secure browser + redirect callback handling:
+
+1. `TrustlyCustomTabsManagerActivity`
+2. `TrustlyRedirectActivity`
+
+`TrustlyRedirectActivity` is configured with a browsable intent filter and scheme from `@string/trustly_url_scheme`.
+
+Merchant implication: with SDK 4.2.0 redirect flow encapsulation, manual merchant redirect Activities are no longer required.
+
+---
+
+## Task 2: Integration Example (Before and After)
+
+Note: these repositories do not include a merchant app/example module under `/app` or `/example`. The snippets below represent merchant-side integration using the SDK public API and launch flow behavior from the SDK source.
+
+### Before (v3.7.0 style)
+
+```kotlin
+val trustlyView = TrustlyView(this)
+
+trustlyView
+    .onBankSelected { _, bankData ->
+        // Continue to light-box after bank selection
+        trustlyView.establish(bankData)
+    }
+    .onReturn { _, returnParams ->
+        // Success flow
+    }
+    .onCancel { _, cancelParams ->
+        // Cancel or failure flow
+    }
+    .selectBankWidget(establishData)
+```
+
+### After (v4.2.0 style)
+
+```kotlin
+val trustlyView = TrustlyView(this)
+
+trustlyView
+    .onBankSelected { _, bankData ->
+        // Continue to light-box after bank selection
+        trustlyView.establish(bankData)
+    }
+    .onReturn { _, returnParams ->
+        // Success flow
+    }
+    .onCancel { _, cancelParams ->
+        // Cancel or failure flow
+    }
+    .setListener { eventName, eventDetails ->
+        // Optional telemetry
+    }
+    .selectBankWidget(establishData)
+```
+
+### What changed under the hood for light-box launch
+
+1. v3 can open custom tabs directly from `TrustlyView` path.
+2. v4 encapsulates secure-browser flow through SDK activities (`TrustlyCustomTabsManagerActivity` and `TrustlyRedirectActivity`) and dispatches return/cancel callbacks.
+
+Merchant callback usage remains effectively the same. In v4, remove any manual redirect Activity and configure `trustly_url_scheme` in `strings.xml`.
+
+If using App Links, send `metadata.deepLinkUrl` instead of `metadata.urlScheme` (mutually exclusive).
+
+`metadata.deepLinkUrl` is a new option and requires Trustly-side enablement. Reach out to Trustly Support before using it in production.
+
+---
+
+## Task 3: Callback Logic Migration
+
+## Did listener handling move to `TrustlyCallback`?
+
+It was already callback-based in v3 and stays callback-based in v4.
+
+What changed is the internal dispatch model:
+
+1. v3: callback handlers are invoked directly from `TrustlyView` flow paths.
+2. v4: callback handlers are still registered on `TrustlyView`, but dispatch is funneled through `TrustlyEvents` and activity-based return handling for secure browser flows.
+
+## Migration guidance for success/error listeners
+
+### v3 style
+
+```kotlin
+trustlyView
+    .onReturn { trustly, params ->
+        // Handle success
+    }
+    .onCancel { trustly, params ->
+        // Handle cancel/error
+    }
+```
+
+### v4 style
+
+```kotlin
+trustlyView
+    .onReturn { trustly, params ->
+        // Handle success
+    }
+    .onCancel { trustly, params ->
+        // Handle cancel/error
+    }
+```
+
+### Practical migration notes
+
+1. Keep your existing `onReturn` and `onCancel` wiring.
+2. If moving Java integration code to Kotlin, use lambda-friendly `fun interface` callbacks.
+3. In v4, treat callback `trustly` argument as nullable in Kotlin callback signatures.
+4. In SDK 4.2.0, delete manual merchant redirect Activity classes.
+5. Deep-link keys are mutually exclusive: send either `metadata.urlScheme` or `metadata.deepLinkUrl`, not both.
+6. If using App Links (`metadata.deepLinkUrl`), complete required Android App Links setup before rollout.
+7. `metadata.deepLinkUrl` is new and requires Trustly-side configuration; contact Trustly Support to enable it.
+8. Keep `setListener` for diagnostics and funnel events.
+
+---
+
+## Merchant Team Implementation Checklist
+
+## Code migration
+
+1. Update dependency to `4.2.0`.
+2. Remove any usage of deprecated factory helper (`Trustly.Instance.create(...)`) and instantiate `TrustlyView` directly.
+3. Keep callback registrations on `TrustlyView`.
+4. Confirm establish flow still triggers from bank selection.
+
+## App configuration
+
+1. Delete any manual redirect Activity class previously used for Trustly callback routing.
+2. Add your scheme in `strings.xml`:
+
+```xml
+<string name="trustly_url_scheme">url_scheme</string>
+```
+
+3. Confirm deep-link strategy is valid and mutually exclusive in establish data:
+    - URL scheme via `metadata.urlScheme`, or
+    - App Links via `metadata.deepLinkUrl`.
+4. If using App Links, complete required platform setup (intent filters, Digital Asset Links, and verified domain configuration).
+5. If using App Links (`metadata.deepLinkUrl`), contact Trustly Support to enable Trustly-side configuration before production rollout.
+6. Validate return-to-app behavior from secure browser on physical devices.
+7. Ensure your release manifest merge does not break SDK-declared activities.
+
+## QA and release
+
+1. Test happy path end-to-end.
+2. Test cancel path end-to-end.
+3. Test transient network failures and recovery.
+4. Test app background/foreground transitions during authentication.
+5. Monitor return success rate and cancellation rate after rollout.
+
+---
+
+## Regression Test Matrix (Recommended)
+
+| Scenario | Expected Result |
+|---|---|
+| Widget loads | Banks are displayed and selectable |
+| Bank selected | `onBankSelected` fires once with provider payload |
+| Light-box success | `onReturn` fires and checkout success flow continues |
+| User cancel/failure | `onCancel` fires and fallback UX appears |
+| Custom tab return | App regains control and flow is resumed |
+| Foreground/background transition | Flow resumes without dead-end state |
+
+---
+
+## Rollout Strategy for Merchant Teams
+
+1. Ship behind a feature flag if possible.
+2. Enable in internal builds first.
+3. Roll out to a small production cohort.
+4. Monitor conversion, return success rate, and cancel/failure trends.
+5. Expand after stability is confirmed.
+
+---
+
+## Reference Files in This Workspace
+
+### v3 references
+
+- [trustly-android-v3/README.md](trustly-android-v3/README.md)
+- [trustly-android-v3/trustly-android-sdk/build.gradle](trustly-android-v3/trustly-android-sdk/build.gradle)
+- [trustly-android-v3/trustly-android-sdk/src/main/AndroidManifest.xml](trustly-android-v3/trustly-android-sdk/src/main/AndroidManifest.xml)
+- [trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/Trustly.java](trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/Trustly.java)
+- [trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyCallback.java](trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyCallback.java)
+- [trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyListener.java](trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyListener.java)
+- [trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyView.java](trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyView.java)
+
+### v4 references
+
+- [trustly-android-v4/README.md](trustly-android-v4/README.md)
+- [trustly-android-v4/trustly-android-sdk/build.gradle](trustly-android-v4/trustly-android-sdk/build.gradle)
+- [trustly-android-v4/trustly-android-sdk/src/main/AndroidManifest.xml](trustly-android-v4/trustly-android-sdk/src/main/AndroidManifest.xml)
+- [trustly-android-v4/trustly-android-sdk/src/main/res/values/strings.xml](trustly-android-v4/trustly-android-sdk/src/main/res/values/strings.xml)
+- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/Trustly.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/Trustly.kt)
+- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyCallback.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyCallback.kt)
+- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyListener.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyListener.kt)
+- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyEvents.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyEvents.kt)
+- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyView.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyView.kt)
+- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/components/TrustlyLightbox.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/components/TrustlyLightbox.kt)
+- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyCustomTabsManagerActivity.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyCustomTabsManagerActivity.kt)
+- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyRedirectActivity.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyRedirectActivity.kt)
+- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/events/TrustlyEventsImpl.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/events/TrustlyEventsImpl.kt)

--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -106,13 +106,12 @@ Action items:
     android:exported="true">
     <intent-filter android:autoVerify="true">
         <action android:name="android.intent.action.VIEW" />
-
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
         <data android:scheme="https" />
-        <data android:host="alpha-merchant.tools.devent.trustly.one" />
-        <data android:path="/start/oauth/app/" />
+        <data android:host="your_host_domain" />
+        <data android:path="/your_path/" />
     </intent-filter>
 </activity>
 ```
@@ -210,6 +209,7 @@ Note: these repositories do not include a merchant app/example module under `/ap
 val trustlyView = TrustlyView(this)
 
 trustlyView
+    .selectBankWidget(establishData)
     .onBankSelected { _, bankData ->
         // Continue to light-box after bank selection
         trustlyView.establish(bankData)
@@ -220,7 +220,6 @@ trustlyView
     .onCancel { _, cancelParams ->
         // Cancel or failure flow
     }
-    .selectBankWidget(establishData)
 ```
 
 ### After (v4.2.0 style)
@@ -229,6 +228,7 @@ trustlyView
 val trustlyView = TrustlyView(this)
 
 trustlyView
+    .selectBankWidget(establishData)
     .onBankSelected { _, bankData ->
         // Continue to light-box after bank selection
         trustlyView.establish(bankData)
@@ -242,7 +242,6 @@ trustlyView
     .setListener { eventName, eventDetails ->
         // Optional telemetry
     }
-    .selectBankWidget(establishData)
 ```
 
 ### What changed under the hood for light-box launch
@@ -271,19 +270,7 @@ What changed is the internal dispatch model:
 
 ## Migration guidance for success/error listeners
 
-### v3 style
-
-```kotlin
-trustlyView
-    .onReturn { trustly, params ->
-        // Handle success
-    }
-    .onCancel { trustly, params ->
-        // Handle cancel/error
-    }
-```
-
-### v4 style
+### v3 and v4 style
 
 ```kotlin
 trustlyView
@@ -367,12 +354,3 @@ trustlyView
 5. Expand after stability is confirmed.
 
 ---
-
-## Reference Files
-
-This repository does not vendor the v3 and v4 SDK source trees side-by-side under
-`trustly-android-v3/...` and `trustly-android-v4/...`, so the previous workspace-relative
-reference links were removed to avoid broken links for readers.
-
-If you want to restore this section later, replace it with verified links to real locations
-such as release tags, branches, or commit permalinks for the corresponding SDK versions.

--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -347,30 +347,11 @@ trustlyView
 
 ---
 
-## Reference Files in This Workspace
+## Reference Files
 
-### v3 references
+This repository does not vendor the v3 and v4 SDK source trees side-by-side under
+`trustly-android-v3/...` and `trustly-android-v4/...`, so the previous workspace-relative
+reference links were removed to avoid broken links for readers.
 
-- [trustly-android-v3/README.md](trustly-android-v3/README.md)
-- [trustly-android-v3/trustly-android-sdk/build.gradle](trustly-android-v3/trustly-android-sdk/build.gradle)
-- [trustly-android-v3/trustly-android-sdk/src/main/AndroidManifest.xml](trustly-android-v3/trustly-android-sdk/src/main/AndroidManifest.xml)
-- [trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/Trustly.java](trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/Trustly.java)
-- [trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyCallback.java](trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyCallback.java)
-- [trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyListener.java](trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyListener.java)
-- [trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyView.java](trustly-android-v3/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyView.java)
-
-### v4 references
-
-- [trustly-android-v4/README.md](trustly-android-v4/README.md)
-- [trustly-android-v4/trustly-android-sdk/build.gradle](trustly-android-v4/trustly-android-sdk/build.gradle)
-- [trustly-android-v4/trustly-android-sdk/src/main/AndroidManifest.xml](trustly-android-v4/trustly-android-sdk/src/main/AndroidManifest.xml)
-- [trustly-android-v4/trustly-android-sdk/src/main/res/values/strings.xml](trustly-android-v4/trustly-android-sdk/src/main/res/values/strings.xml)
-- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/Trustly.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/Trustly.kt)
-- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyCallback.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyCallback.kt)
-- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyListener.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyListener.kt)
-- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyEvents.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/interfaces/TrustlyEvents.kt)
-- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyView.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyView.kt)
-- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/components/TrustlyLightbox.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/components/TrustlyLightbox.kt)
-- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyCustomTabsManagerActivity.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyCustomTabsManagerActivity.kt)
-- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyRedirectActivity.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyRedirectActivity.kt)
-- [trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/events/TrustlyEventsImpl.kt](trustly-android-v4/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/events/TrustlyEventsImpl.kt)
+If you want to restore this section later, replace it with verified links to real locations
+such as release tags, branches, or commit permalinks for the corresponding SDK versions.

--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -97,10 +97,30 @@ Action items:
     - URL scheme: `metadata.urlScheme`
     - App Links: `metadata.deepLinkUrl`
 4. `metadata.urlScheme` and `metadata.deepLinkUrl` are mutually exclusive. Send only one, never both.
-5. App Links require additional configuration (for example, AndroidManifest intent filters, Digital Asset Links, and domain association validation).
-6. `metadata.deepLinkUrl` (App Links) is new and also requires Trustly-side configuration/enablement.
-7. Contact Trustly Support to enable App Links before rollout.
-8. Test return-to-app behavior on real devices.
+5. For `metadata.deepLinkUrl` to work, override the SDK default App Links intent filter in your own `AndroidManifest.xml` by redeclaring `TrustlyRedirectActivity` with your App Link domain/path:
+
+```xml
+<!-- Overriding the SDK's default redirect activity allows you to handle the redirect in your own way. -->
+<activity
+    android:name="net.trustly.android.sdk.views.TrustlyRedirectActivity"
+    android:exported="true">
+    <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data android:scheme="https" />
+        <data android:host="alpha-merchant.tools.devent.trustly.one" />
+        <data android:path="/start/oauth/app/" />
+    </intent-filter>
+</activity>
+```
+
+6. App Links also require Digital Asset Links/domain association validation for your App Link host.
+7. `metadata.deepLinkUrl` (App Links) is new and also requires Trustly-side configuration/enablement.
+8. Contact Trustly Support to enable App Links before rollout.
+9. Test return-to-app behavior on real devices.
 
 ## 5. Re-test callback behavior end-to-end
 
@@ -309,10 +329,11 @@ trustlyView
 3. Confirm deep-link strategy is valid and mutually exclusive in establish data:
     - URL scheme via `metadata.urlScheme`, or
     - App Links via `metadata.deepLinkUrl`.
-4. If using App Links, complete required platform setup (intent filters, Digital Asset Links, and verified domain configuration).
-5. If using App Links (`metadata.deepLinkUrl`), contact Trustly Support to enable Trustly-side configuration before production rollout.
-6. Validate return-to-app behavior from secure browser on physical devices.
-7. Ensure your release manifest merge does not break SDK-declared activities.
+4. If using App Links (`metadata.deepLinkUrl`), override `TrustlyRedirectActivity` in your app `AndroidManifest.xml` with your own `https` host/path intent filter.
+5. If using App Links, complete required platform setup (intent filters, Digital Asset Links, and verified domain configuration).
+6. If using App Links (`metadata.deepLinkUrl`), contact Trustly Support to enable Trustly-side configuration before production rollout.
+7. Validate return-to-app behavior from secure browser on physical devices.
+8. Ensure your release manifest merge does not break SDK-declared activities.
 
 ## QA and release
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ This repository contains the source code for the Trustly Android SDK, including 
 [Get started](https://amer.developers.trustly.com/payments/docs/getting-started) with Trustly concepts and sandbox environment testing.
 Understand the functions and user flows of [Trustly UI](https://amer.developers.trustly.com/payments/docs/sdk).
 
+## Upgrading
+---
+If you are upgrading from a previous version, see the [Migration Guide](MIGRATION-GUIDE.md) for version-specific instructions.
+
 ## Installation
 ---
 


### PR DESCRIPTION
Adds a structured migration guide MIGRATION-GUIDE.md to help merchant Android engineers upgrade their Trustly integration from v3 to v4.2.0. The guide covers the high-impact API changes, a v3→v4 mapping table, and a step-by-step upgrade plan including dependency update, controller migration, callback handling via TrustlySDKProtocol, and establish data contract verification.

The README.md has also been updated to surface the guide in two places: a dedicated Upgrading section near the top of the file, and an inline callout within the existing v3→v4 "Key Changes" notice.
### Description

---

### Relevant Commits

[Adding a migration guide from v3 -> v4.2.0](https://github.com/TrustlyInc/trustly-android/commit/db2ea83cdc26761e7f2d745e0d46f7eafa306cbd)

---

### Requirements

- [x] Changes were properly tested (attach evidence if applicable)
- [x] Repository's code-style/linting compliant

---

### Evidence

Documentation-only changes. No runtime code was modified. Verified that all internal links MIGRATION-GUIDE.md resolve correctly when browsed on GitHub.

---

### Additional Information

None
