### PR TITLE
[DEV-299412] Maven Central local release build

### DIFF
--- a/trustly-android-sdk/publish-remote.gradle
+++ b/trustly-android-sdk/publish-remote.gradle
@@ -73,10 +73,15 @@ afterEvaluate {
 }
 
 signing {
-    useInMemoryPgpKeys(
-            rootProject.ext["signing.keyId"],
-            rootProject.ext["signing.key"],
-            rootProject.ext["signing.password"]
-    )
-    sign publishing.publications
+    def signingKey = rootProject.ext["signing.key"]
+    def signingKeyId = rootProject.ext["signing.keyId"]
+    def signingPassword = rootProject.ext["signing.password"]
+
+    // Only sign when credentials are present — skips signing for local builds
+    required { signingKey != null && !signingKey.isEmpty() }
+
+    if (signingKey != null && !signingKey.isEmpty()) {
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+        sign publishing.publications
+    }
 }


### PR DESCRIPTION
## Why

Local publication was failing with:

- `Execution failed for task ':signReleasePublication'`
- `Could not read PGP secret key`

Signing was always attempted, including local-only builds where signing credentials were not configured.

## What Changed

### `publish-remote.gradle`

- Kept existing `maven-publish` publication metadata and coordinates.
- Made signing conditional:
  - Reads `signing.key`, `signing.keyId`, and `signing.password` from `rootProject.ext`.
  - Requires/enables signing only when `signing.key` is present and non-empty.
  - Skips signing automatically for local builds without keys.

### `publish-root.gradle`

- No behavioral change required for this fix; it still loads values from `local.properties` or environment variables.

## How To Use It

### Local developer flow (no signing required)

1. Build and publish SDK to local Maven cache:

```zsh
cd "../trustly-android/trustly-android-sdk"
./gradlew publishToMavenLocal
```

2. Confirm local artifact exists:

```zsh
ls ~/.m2/repository/net/trustly/trustly-android-sdk/
ls ~/.m2/repository/net/trustly/trustly-android-sdk/4.2.0/
```

3. Consume from another project (consumer app):
- In consumer `settings.gradle` add the Maven Local reference:

```groovy
dependencyResolutionManagement {
    repositories {
        mavenLocal() // Add reference to Maven Local
        google()
        mavenCentral()
    }
}
```

- In consumer module `build.gradle`:

```groovy
implementation 'net.trustly:trustly-android-sdk:4.2.0'
```

### CI/remote publish flow (signing enabled when keys exist)

Provide these env vars in CI:
- `SIGNING_KEY`
- `SIGNING_KEY_ID`
- `SIGNING_PASSWORD`
- plus Sonatype credentials already used by publishing flow

Then run your normal publish task. With `SIGNING_KEY` present, signing runs automatically.

## How To Test / Validate

### 1) Local publish without signing credentials

```zsh
cd "../trustly-android/trustly-android-sdk"
./gradlew publishToMavenLocal
```

Expected:
- Build succeeds
- No failure from `:signReleasePublication`

### 2) Validate generated local artifacts

Expected under `~/.m2/repository/net/trustly/trustly-android-sdk/4.2.0/`:
- `trustly-android-sdk-4.2.0.aar`
- `trustly-android-sdk-4.2.0-sources.jar`
- `trustly-android-sdk-4.2.0.pom`
- `trustly-android-sdk-4.2.0.module`

### 3) Optional CI-like check with signing credentials

Set signing env vars and run remote publish; signing should execute.

## Edge Errors / Expected Behavior

- **No signing credentials (local)**: signing skipped, `publishToMavenLocal` succeeds.
- **Invalid signing key format**: signing fails with key parsing error (expected).
- **Empty signing env vars**: treated as missing, signing skipped.
- **Remote publish without signing where repository requires it**: publish/sign flow fails (expected).

## Risk

Low.
Change is isolated to signing activation logic; publication metadata and artifact coordinates are unchanged.

