### PR TITLE
[DEV-303544] Removing trustlyContext from return and cancel methods

### DIFF
--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/EstablishDataManager.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/EstablishDataManager.kt
@@ -1,6 +1,8 @@
 package net.trustly.android.sdk.util
 
+import android.content.Context
 import net.trustly.android.sdk.util.TrustlyConstants.PAYMENT_PROVIDER_ID
+import net.trustly.android.sdk.util.last_used.LastUsedBankManager
 
 object EstablishDataManager {
 
@@ -15,6 +17,15 @@ object EstablishDataManager {
     fun updatePaymentProviderId(paymentProviderId: String): MutableMap<String, String> {
         establishData[PAYMENT_PROVIDER_ID] = paymentProviderId
         return getEstablishData()
+    }
+
+    fun saveLastUsedBankByTrustlyContext(context: Context, establishData: Map<String, String>): Map<String, String> {
+        establishData[TrustlyConstants.TRUSTLY_CONTEXT]?.let {
+            LastUsedBankManager.saveLastUsedBank(context, it)
+        }
+        return establishData.toMutableMap().apply {
+            remove(TrustlyConstants.TRUSTLY_CONTEXT)
+        }
     }
 
 }

--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/EstablishDataManager.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/util/EstablishDataManager.kt
@@ -19,11 +19,11 @@ object EstablishDataManager {
         return getEstablishData()
     }
 
-    fun saveLastUsedBankByTrustlyContext(context: Context, establishData: Map<String, String>): Map<String, String> {
-        establishData[TrustlyConstants.TRUSTLY_CONTEXT]?.let {
+    fun saveLastUsedBankByTrustlyContext(context: Context, transactionDetails: Map<String, String>): Map<String, String> {
+        transactionDetails[TrustlyConstants.TRUSTLY_CONTEXT]?.let {
             LastUsedBankManager.saveLastUsedBank(context, it)
         }
-        return establishData.toMutableMap().apply {
+        return transactionDetails.toMutableMap().apply {
             remove(TrustlyConstants.TRUSTLY_CONTEXT)
         }
     }

--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyCustomTabsManagerActivity.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/TrustlyCustomTabsManagerActivity.kt
@@ -8,8 +8,7 @@ import android.os.Bundle
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
 import net.trustly.android.sdk.interfaces.TrustlyEvents
-import net.trustly.android.sdk.util.TrustlyConstants
-import net.trustly.android.sdk.util.last_used.LastUsedBankManager
+import net.trustly.android.sdk.util.EstablishDataManager
 import net.trustly.android.sdk.views.events.TrustlyEventsImpl
 
 class TrustlyCustomTabsManagerActivity : Activity() {
@@ -35,10 +34,9 @@ class TrustlyCustomTabsManagerActivity : Activity() {
 
         val serializableExtra = intent.getSerializableExtra(ESTABLISH_DATA)
         if (serializableExtra != null) {
-            val transactionDetails = serializableExtra as Map<String, String>
-            transactionDetails[TrustlyConstants.TRUSTLY_CONTEXT]?.let {
-                LastUsedBankManager.saveLastUsedBank(this, it)
-            }
+            val establishData = serializableExtra as Map<String, String>
+            val transactionDetails =
+                EstablishDataManager.saveLastUsedBankByTrustlyContext(this, establishData)
             if (transactionDetails[STATUS_PARAM] == SUCCESS_STATUS_PARAM) {
                 this.trustlyEvents.handleOnReturn(this.trustlyView, transactionDetails)
             } else {

--- a/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/clients/TrustlyWebViewClient.kt
+++ b/trustly-android-sdk/src/main/java/net/trustly/android/sdk/views/clients/TrustlyWebViewClient.kt
@@ -9,9 +9,7 @@ import android.webkit.WebViewClient
 import androidx.annotation.RequiresApi
 import net.trustly.android.sdk.interfaces.TrustlyEvents
 import net.trustly.android.sdk.util.EstablishDataManager
-import net.trustly.android.sdk.util.TrustlyConstants
 import net.trustly.android.sdk.util.UrlUtils
-import net.trustly.android.sdk.util.last_used.LastUsedBankManager
 import net.trustly.android.sdk.views.TrustlyView
 import java.util.regex.Pattern
 
@@ -81,10 +79,11 @@ class TrustlyWebViewClient(
 
     private fun handleWebViewClientShouldOverrideUrlLoading(url: String): Boolean {
         if (url.startsWith(returnURL) || url.startsWith(cancelURL)) {
-            val queryParametersFromUrl = UrlUtils.getQueryParametersFromUrl(url)
-            queryParametersFromUrl[TrustlyConstants.TRUSTLY_CONTEXT]?.let {
-                LastUsedBankManager.saveLastUsedBank(trustlyView.context, it)
-            }
+            val queryParametersFromUrl =
+                EstablishDataManager.saveLastUsedBankByTrustlyContext(
+                    trustlyView.context,
+                    UrlUtils.getQueryParametersFromUrl(url)
+                )
             if (url.startsWith(returnURL)) {
                 trustlyEvents.handleOnReturn(trustlyView, queryParametersFromUrl)
             } else {

--- a/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/EstablishDataManagerTest.kt
+++ b/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/EstablishDataManagerTest.kt
@@ -1,10 +1,40 @@
 package net.trustly.android.sdk.util
 
+import android.content.Context
+import android.content.SharedPreferences
 import net.trustly.android.sdk.util.TrustlyConstants.PAYMENT_PROVIDER_ID
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito.clearInvocations
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 class EstablishDataManagerTest {
+
+    @Mock
+    private lateinit var mockSharedPreferencesEditor: SharedPreferences.Editor
+
+    @Mock
+    private lateinit var mockSharedPreferences: SharedPreferences
+
+    @Mock
+    private lateinit var mockContext: Context
+
+    @Before
+    fun setUp() {
+        mockSharedPreferencesEditor = mock(SharedPreferences.Editor::class.java)
+        mockSharedPreferences = mock(SharedPreferences::class.java)
+        mockContext = mock(Context::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearInvocations(mockSharedPreferencesEditor, mockSharedPreferences, mockContext)
+    }
 
     @Test
     fun shouldValidateEstablishDataManagerUpdateEstablishData() {
@@ -20,6 +50,28 @@ class EstablishDataManagerTest {
         EstablishDataManager.updatePaymentProviderId(paymentProviderId)
         val result = EstablishDataManager.getEstablishData()
         assertEquals(paymentProviderId, result[PAYMENT_PROVIDER_ID])
+    }
+
+    @Test
+    fun shouldValidateEstablishDataManagerSaveLastUsedBankByTrustlyContext() {
+        `when`(mockSharedPreferencesEditor.putString(anyString(), anyString())).thenReturn(mockSharedPreferencesEditor)
+        `when`(mockSharedPreferences.edit()).thenReturn(mockSharedPreferencesEditor)
+        `when`(mockContext.getSharedPreferences("LAST_USED_BANK", Context.MODE_PRIVATE)).thenReturn(mockSharedPreferences)
+
+        val establishData = mapOf("trustlyContext" to "context123", "key" to "value", "key2" to "value2")
+        val result = EstablishDataManager.saveLastUsedBankByTrustlyContext(mockContext, establishData)
+        assertEquals("value", result["key"])
+        assertEquals("value2", result["key2"])
+        assertEquals(null, result["trustlyContext"])
+    }
+
+    @Test
+    fun shouldValidateEstablishDataManagerSaveLastUsedBankByWithoutTrustlyContext() {
+        val establishData = mapOf("key" to "value", "key2" to "value2")
+        val result = EstablishDataManager.saveLastUsedBankByTrustlyContext(mockContext, establishData)
+        assertEquals("value", result["key"])
+        assertEquals("value2", result["key2"])
+        assertEquals(null, result["trustlyContext"])
     }
 
 }

--- a/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/EstablishDataManagerTest.kt
+++ b/trustly-android-sdk/src/test/java/net/trustly/android/sdk/util/EstablishDataManagerTest.kt
@@ -26,6 +26,8 @@ class EstablishDataManagerTest {
 
     @Before
     fun setUp() {
+        EstablishDataManager.getEstablishData().clear()
+
         mockSharedPreferencesEditor = mock(SharedPreferences.Editor::class.java)
         mockSharedPreferences = mock(SharedPreferences::class.java)
         mockContext = mock(Context::class.java)
@@ -66,7 +68,7 @@ class EstablishDataManagerTest {
     }
 
     @Test
-    fun shouldValidateEstablishDataManagerSaveLastUsedBankByWithoutTrustlyContext() {
+    fun shouldValidateEstablishDataManagerSaveLastUsedBankWithoutTrustlyContext() {
         val establishData = mapOf("key" to "value", "key2" to "value2")
         val result = EstablishDataManager.saveLastUsedBankByTrustlyContext(mockContext, establishData)
         assertEquals("value", result["key"])


### PR DESCRIPTION
### Description

This PR addresses an intermittent issue where redirect signature validation fails for merchants due to an unexpected parameter appended to the redirect URLs.

---

### Changes

Stripped the **trustlyContext** parameter from both the return and cancel callback methods.

---

### Requirements

- [x] Changes were properly tested (attach evidence if applicable)
- [x] Repository's code-style/linting compliant

---

### Additional Information

- Merchants: Prevents unexpected signature validation failures for merchants following the documented process.
- System: Resolves an intermittent and difficult-to-reproduce bug in the callback URL formatting.
